### PR TITLE
Kseniia's solution

### DIFF
--- a/src/bind.js
+++ b/src/bind.js
@@ -18,8 +18,9 @@
  *
  * @return {Function}
  */
-function bind(callback) {
-  // write code here
+function bind(callback, ...params) {
+  const f = callback;
+  return (...extraParams) => f(...params, ...extraParams);
 }
 
 module.exports = bind;


### PR DESCRIPTION
объявила дополнительную переменную для callback функции, потому что линтер не пропустил напрямую обращения к callback из параметров функции-фабрики, не совсем понимаю, почему;
Выводил такую ошибку
"Unexpected literal in error position of callback"